### PR TITLE
Fix: Allow scripture font size to shrink to fit.

### DIFF
--- a/YourWord/Views/Components/ScriptureView.swift
+++ b/YourWord/Views/Components/ScriptureView.swift
@@ -16,6 +16,7 @@ struct ScriptureView: View {
       Text(text)
         .font(/*@START_MENU_TOKEN@*/.title/*@END_MENU_TOKEN@*/)
         .padding()
+        .minimumScaleFactor(0.5)
       Text(source)
         .padding()
     }

--- a/YourWord/Views/MemorizeView.swift
+++ b/YourWord/Views/MemorizeView.swift
@@ -71,6 +71,9 @@ struct MemorizeView: View {
             markMemorizationAsCompleted()
           }
           .padding(.top, 20)
+        } else {
+          Spacer()
+            .frame(height: 116)
         }
 
         Spacer()


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

Fixes issue #3 where long scripture text was being cut off. 

For consistency, add a spacer under the scripture text view so that that content view doesn't get too close to the page view buttons.

**Screenshots**

![Simulator Screenshot - iPhone 15 Pro Max - 2023-12-10 at 23 22 02](https://github.com/caabernathy/YourWord/assets/691109/6638bcd1-f162-437e-ab6c-15c29e0a2e61)
