### PR TITLE
Fix daily memorize page index navigation

### DIFF
--- a/YourWord.xcodeproj/project.pbxproj
+++ b/YourWord.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		CB003F452B13588C008584F1 /* Date+RawRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB003F442B13588C008584F1 /* Date+RawRepresentable.swift */; };
 		CB0741702B05D0880000CCCC /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CB07416F2B05D0880000CCCC /* Launch Screen.storyboard */; };
+		CB1394BA2B5B500F0027707D /* DayManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB1394B92B5B500F0027707D /* DayManager.swift */; };
 		CB1BA6E92B12D02F004F4CBE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB1BA6E82B12D02F004F4CBE /* AppDelegate.swift */; };
 		CB1BA6EB2B132354004F4CBE /* SettingsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB1BA6EA2B132354004F4CBE /* SettingsManager.swift */; };
 		CBA2C7B22B082D9B00A27DE1 /* ScriptureManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBA2C7B12B082D9B00A27DE1 /* ScriptureManager.swift */; };
@@ -57,6 +58,7 @@
 /* Begin PBXFileReference section */
 		CB003F442B13588C008584F1 /* Date+RawRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+RawRepresentable.swift"; sourceTree = "<group>"; };
 		CB07416F2B05D0880000CCCC /* Launch Screen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
+		CB1394B92B5B500F0027707D /* DayManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayManager.swift; sourceTree = "<group>"; };
 		CB1BA6E82B12D02F004F4CBE /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		CB1BA6EA2B132354004F4CBE /* SettingsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsManager.swift; sourceTree = "<group>"; };
 		CBA2C7B12B082D9B00A27DE1 /* ScriptureManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptureManager.swift; sourceTree = "<group>"; };
@@ -120,6 +122,7 @@
 				CB1BA6EA2B132354004F4CBE /* SettingsManager.swift */,
 				CBA2C7B12B082D9B00A27DE1 /* ScriptureManager.swift */,
 				CBFFAB342B0B3DF700C864C9 /* ScriptureModelContainer.swift */,
+				CB1394B92B5B500F0027707D /* DayManager.swift */,
 			);
 			path = Managers;
 			sourceTree = "<group>";
@@ -375,6 +378,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CB1394BA2B5B500F0027707D /* DayManager.swift in Sources */,
 				CBFFAB352B0B3DF700C864C9 /* ScriptureModelContainer.swift in Sources */,
 				CBF969212B15B300003D90FE /* DayOfWeekLabelView.swift in Sources */,
 				CBAC66612B0DB5C30044BBE7 /* MainTabView.swift in Sources */,

--- a/YourWord/AppDelegate.swift
+++ b/YourWord/AppDelegate.swift
@@ -10,16 +10,18 @@ import UserNotifications
 
 class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate, ObservableObject {
 
-  var notificationData: Int?
-
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
     UNUserNotificationCenter.current().delegate = self
     return true
   }
 
   func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
-    if let day = response.notification.request.content.userInfo["day"] as? Int {
-      notificationData = day
+    if response.notification.request.identifier.starts(with: NotificationManager.NotificationConstants.dailyNotificationName) {
+      if let day = response.notification.request.content.userInfo["day"] as? Int {
+        DispatchQueue.main.async {
+          NotificationManager.shared.didReceiveNotification(for: day)
+        }
+      }
     }
     completionHandler()
   }

--- a/YourWord/Managers/DayManager.swift
+++ b/YourWord/Managers/DayManager.swift
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) Christine Abernathy.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import Foundation
+
+@Observable class DayManager {
+  var currentDayOfWeek = Calendar.current.component(.weekday, from: Date())
+
+  static let shared = DayManager()
+
+  private init() {}
+
+  func updateDay() {
+    let newDayOfWeek = Calendar.current.component(.weekday, from: Date())
+    if newDayOfWeek != currentDayOfWeek {
+      currentDayOfWeek = newDayOfWeek
+    }
+  }
+
+}

--- a/YourWord/Managers/NotificationManager.swift
+++ b/YourWord/Managers/NotificationManager.swift
@@ -8,12 +8,14 @@
 import Foundation
 import UserNotifications
 
-class NotificationManager {
+@Observable class NotificationManager {
   enum NotificationConstants {
     static let dailyNotificationName = "memorizeDay"
   }
 
   static let shared = NotificationManager()
+  var shouldSwitchToHomeTab = false
+  var notificationDayOfWeek: Int?
 
   private init() {}
 
@@ -23,6 +25,16 @@ class NotificationManager {
         self.scheduleDailyNotifications(hour: hour, minute: minute)
       }
     }
+  }
+
+  func didReceiveNotification(for day: Int) {
+    shouldSwitchToHomeTab = true
+    notificationDayOfWeek = day
+  }
+
+  func clearNotificationDat() {
+    shouldSwitchToHomeTab = false
+    notificationDayOfWeek = nil
   }
 
   private func requestAuthorization(completion: @escaping  (Bool) -> Void) {

--- a/YourWord/Views/MainTabView.swift
+++ b/YourWord/Views/MainTabView.swift
@@ -26,6 +26,7 @@ struct MainTabView: View {
 
   @SceneStorage("MainTabView.SelectedTab") private var selectedTab: Int = 1
   @State private var savedScriptures: [Scripture] = []
+  let shouldSwitchToHomeTab = NotificationManager.shared.shouldSwitchToHomeTab
 
   var body: some View {
     TabView(selection: $selectedTab) {
@@ -47,6 +48,14 @@ struct MainTabView: View {
           Label("Settings", systemImage: "gearshape.fill")
         }
         .tag(2)
+    }
+    .onChange(of: shouldSwitchToHomeTab) {
+      if shouldSwitchToHomeTab {
+        selectedTab = 1
+      }
+    }
+    .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { _ in
+      DayManager.shared.updateDay()
     }
   }
 }


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->

Explain the **details** for making this change. What existing problem does the pull request solve?

Addresses the following:

* #1
* If you click back and forth from the memorize tab to a different tab, the day you were in is always reset to the current day.
* If you were in the memorize tab, close the app and reopen it when a new day has started, the new day's verse isn't loaded.

**Test plan (required)**

Test 1:
1. Opened app when there were several days of daily memory verses
2. Clicked the first day of week verse
3. Clicked on the Settings tab
4. Clicked back to the Memorize tab
5. Ensure that the view is the same as before, the first day

Test 2:
1. Opened app when there were several days of daily memory verses
2. Ensure you're on a verse that is a different day from the notification
3. Wait for a notification to come in (ideally several days worth)
4. Close the app
5. Click on a notification
6. Ensure you are brought to the day that matches the notification

Test 3 (run this test on a day before Saturday)
1. Open the app
2. Go to the Settings tab
3. Enable Show All Days
4. Go to the Memorize tab
5. Click on Saturday (last day of the week)
6. Got to Settings and disable Show All Days
7. Go to Memorize tab
8. Ensure that the page has been reset to the current day of the week

