### PR TITLE
Refactor logic for updating daily scripture reveal

### DIFF
--- a/YourWord.xcodeproj/project.pbxproj
+++ b/YourWord.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		CB1394BC2B5CD30A0027707D /* View+toast.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB1394BB2B5CD30A0027707D /* View+toast.swift */; };
 		CB1BA6E92B12D02F004F4CBE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB1BA6E82B12D02F004F4CBE /* AppDelegate.swift */; };
 		CB1BA6EB2B132354004F4CBE /* SettingsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB1BA6EA2B132354004F4CBE /* SettingsManager.swift */; };
+		CB9432AD2B60C997005F9E48 /* ScriptureViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9432AC2B60C997005F9E48 /* ScriptureViewModel.swift */; };
 		CBA2C7B22B082D9B00A27DE1 /* ScriptureManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBA2C7B12B082D9B00A27DE1 /* ScriptureManager.swift */; };
 		CBA2C7B52B09BB1700A27DE1 /* StarterScriptures.json in Resources */ = {isa = PBXBuildFile; fileRef = CBA2C7B42B09BB1700A27DE1 /* StarterScriptures.json */; };
 		CBAC66612B0DB5C30044BBE7 /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBAC66602B0DB5C30044BBE7 /* MainTabView.swift */; };
@@ -63,6 +64,7 @@
 		CB1394BB2B5CD30A0027707D /* View+toast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+toast.swift"; sourceTree = "<group>"; };
 		CB1BA6E82B12D02F004F4CBE /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		CB1BA6EA2B132354004F4CBE /* SettingsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsManager.swift; sourceTree = "<group>"; };
+		CB9432AC2B60C997005F9E48 /* ScriptureViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptureViewModel.swift; sourceTree = "<group>"; };
 		CBA2C7B12B082D9B00A27DE1 /* ScriptureManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptureManager.swift; sourceTree = "<group>"; };
 		CBA2C7B42B09BB1700A27DE1 /* StarterScriptures.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = StarterScriptures.json; sourceTree = "<group>"; };
 		CBAC66602B0DB5C30044BBE7 /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
@@ -117,6 +119,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		CB9432AB2B60C964005F9E48 /* ViewModels */ = {
+			isa = PBXGroup;
+			children = (
+				CB9432AC2B60C997005F9E48 /* ScriptureViewModel.swift */,
+			);
+			path = ViewModels;
+			sourceTree = "<group>";
+		};
 		CBA2C7B02B082D5000A27DE1 /* Managers */ = {
 			isa = PBXGroup;
 			children = (
@@ -167,6 +177,7 @@
 				CBA2C7B02B082D5000A27DE1 /* Managers */,
 				CBD43F962B01DE6B003CF5F7 /* Models */,
 				CBD43F9C2B01E096003CF5F7 /* Views */,
+				CB9432AB2B60C964005F9E48 /* ViewModels */,
 				CBA2C7B32B09B83E00A27DE1 /* Resources */,
 				CBD43F702B01DD24003CF5F7 /* Assets.xcassets */,
 				CBD43F722B01DD24003CF5F7 /* Preview Content */,
@@ -381,6 +392,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CB9432AD2B60C997005F9E48 /* ScriptureViewModel.swift in Sources */,
 				CB1394BA2B5B500F0027707D /* ScheduleManager.swift in Sources */,
 				CBFFAB352B0B3DF700C864C9 /* ScriptureModelContainer.swift in Sources */,
 				CBF969212B15B300003D90FE /* DayOfWeekLabelView.swift in Sources */,

--- a/YourWord/Managers/ScriptureManager.swift
+++ b/YourWord/Managers/ScriptureManager.swift
@@ -32,54 +32,6 @@ import Foundation
     return scriptures
   }
 
-  func maskScriptureText(_ translation: Translation) -> [String] {
-    var words = translation.text.components(separatedBy: " ")
-    var replacedWords: [String] = []
-    // Mask words in a passage based on mask key configured during initialization
-    for i in 0..<memorizeCount {
-      // Modifying words
-      if !translation.maskingKey.isEmpty {
-        for j in 0..<words.count {
-          if i >= translation.maskingKey[j] {
-            words[j] = replaceWithUnderscore(text: words[j])
-          }
-        }
-      }
-      replacedWords.append(words.joined(separator: " "))
-    }
-    return replacedWords
-  }
-
-  func maskSriptureReference(_ passage: Passage) -> [String] {
-    var replacedSources: [String] = []
-    // Mask source
-    for i in 0..<memorizeCount {
-      // Modifiying source
-      if !passage.maskingKey.isEmpty && passage.maskingKey[i] {
-        // Switch up the masking, last element will be msked
-        let lastRound = (i == memorizeCount - 1)
-        // Even, mask book
-        let modifiedBook = lastRound || (i % 2 == 0) ? replaceWithUnderscore(text: passage.book) : passage.book
-        // Odd, mask chapter and verses
-        let modifiedChapter = lastRound || (i % 2 != 0) ? replaceWithUnderscore(text: String(passage.chapter)) : String(passage.chapter)
-        let modifiedVerses = lastRound || (i % 2 != 0) ? replaceWithUnderscore(text: passage.verses) : passage.verses
-        replacedSources.append(formatSource(book: modifiedBook, chapter: modifiedChapter, verses: modifiedVerses))
-      } else {
-        // Source not being modified
-        replacedSources.append(formatSource(book: passage.book, chapter: String(passage.chapter), verses: passage.verses))
-      }
-    }
-    return replacedSources
-  }
-
-  private func formatSource(book: String, chapter: String, verses: String) -> String {
-    return "\(book) \(chapter):\(verses)"
-  }
-
-  private func replaceWithUnderscore(text: String) -> String {
-    return text.replacingOccurrences(of: "\\w", with: "_", options: .regularExpression)
-  }
-
   func createTextMaskingKey(for text: String) -> [Int] {
     let words = text.components(separatedBy: " ")
     var textKey = (1..<memorizeCount).map { $0 }

--- a/YourWord/ViewModels/ScriptureViewModel.swift
+++ b/YourWord/ViewModels/ScriptureViewModel.swift
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) Christine Abernathy.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import Foundation
+
+@Observable class ScriptureViewModel {
+  private var scripture: Scripture
+
+  var memoryTexts: [String] = []
+  var memorySources: [String] = []
+
+  init(scripture: Scripture) {
+    self.scripture = scripture
+  }
+
+  func mask(for bibleTranslation: BibleTranslation, days numberOfDaysToShow: Int) -> Bool {
+    guard
+      let scriptureText = scripture.translation(for: bibleTranslation) else { return false }
+    let maskedTexts = maskScriptureText(scriptureText)
+    let maskedSources = maskSriptureReference(scripture.passage)
+    memoryTexts = Array(maskedTexts.prefix(numberOfDaysToShow))
+    memorySources = Array(maskedSources.prefix(numberOfDaysToShow))
+    return true
+  }
+
+  func maskScriptureText(_ translation: Translation) -> [String] {
+    var words = translation.text.components(separatedBy: " ")
+    var replacedWords: [String] = []
+    // Mask words in a passage based on mask key configured during initialization
+    for i in 0..<ScriptureManager.shared.memorizeCount {
+      // Modifying words
+      if !translation.maskingKey.isEmpty {
+        for j in 0..<words.count {
+          if i >= translation.maskingKey[j] {
+            words[j] = replaceWithUnderscore(text: words[j])
+          }
+        }
+      }
+      replacedWords.append(words.joined(separator: " "))
+    }
+    return replacedWords
+  }
+
+  func maskSriptureReference(_ passage: Passage) -> [String] {
+    var replacedSources: [String] = []
+    // Mask source
+    for i in 0..<ScriptureManager.shared.memorizeCount {
+      // Modifiying source
+      if !passage.maskingKey.isEmpty && passage.maskingKey[i] {
+        // Switch up the masking, last element will be msked
+        let lastRound = (i == ScriptureManager.shared.memorizeCount - 1)
+        // Even, mask book
+        let modifiedBook = lastRound || (i % 2 == 0) ? replaceWithUnderscore(text: passage.book) : passage.book
+        // Odd, mask chapter and verses
+        let modifiedChapter = lastRound || (i % 2 != 0) ? replaceWithUnderscore(text: String(passage.chapter)) : String(passage.chapter)
+        let modifiedVerses = lastRound || (i % 2 != 0) ? replaceWithUnderscore(text: passage.verses) : passage.verses
+        replacedSources.append(formatSource(book: modifiedBook, chapter: modifiedChapter, verses: modifiedVerses))
+      } else {
+        // Source not being modified
+        replacedSources.append(formatSource(book: passage.book, chapter: String(passage.chapter), verses: passage.verses))
+      }
+    }
+    return replacedSources
+  }
+
+  private func replaceWithUnderscore(text: String) -> String {
+    return text.replacingOccurrences(of: "\\w", with: "_", options: .regularExpression)
+  }
+
+  private func formatSource(book: String, chapter: String, verses: String) -> String {
+    return "\(book) \(chapter):\(verses)"
+  }
+}

--- a/YourWord/Views/MainTabView.swift
+++ b/YourWord/Views/MainTabView.swift
@@ -64,7 +64,9 @@ struct MainTabView: View {
     let refrshScripture = ScheduleManager.shared.updateCheck()
     if refrshScripture && currentScripture.count > 0 {
       // Mark the scripture as complete
-      currentScripture[0].completed = true
+      withAnimation(.smooth) {
+        currentScripture[0].completed = true
+      }
     }
   }
 }


### PR DESCRIPTION
Explain the **details** for making this change. What existing problem does the pull request solve?

Logic for updating the daily reveal is quite messy so doing some cleanup and making use a view model to help setup the masking.

**Test plan (required)**
1. Test correct date shown when a notification comes in.
2. Test scripture page index behaves well when Show All Days is toggled on and off.
3. Test the Memorize page index is retained when switching back and forth from Memorize tab.
4. Test memorize scripture refreshed when a new week starts.
