### PR TITLE
Add a little color to the memorize view

### DIFF
--- a/YourWord/Views/MemorizeView.swift
+++ b/YourWord/Views/MemorizeView.swift
@@ -9,6 +9,9 @@ import SwiftUI
 import SwiftData
 
 struct MemorizeView: View {
+  // Access the current color scheme
+  @Environment(\.colorScheme) var colorScheme
+
   var scripture: Scripture
   var isDailyReveal: Bool
   var scriptureViewModel: ScriptureViewModel
@@ -25,10 +28,13 @@ struct MemorizeView: View {
   let notificationDayOfWeek = NotificationManager.shared.notificationDayOfWeek
   let currentDayOfWeek = ScheduleManager.shared.currentDayOfWeek
 
+  let colors: [Color] = [.blue, .green, .purple, .brown, .orange]
+
   @State private var dragOffset: CGFloat = 0
   @State private var pageIndex = 0
   @State private var isSetupDone = false
   @State private var showToast = false
+  @State private var viewBackgroundColor: Color = .clear
 
   var body: some View {
     let numberOfDaysToShow = isDailyReveal && !dailyRevealOverride ? currentDayOfWeek : pageViewCount
@@ -89,12 +95,17 @@ struct MemorizeView: View {
         Spacer()
       }
     }
+    .background(colorScheme == .dark ? Color.black.opacity(0.3) : .clear)
+    .background(colorScheme == .dark ?
+                LinearGradient(gradient: Gradient(colors: [viewBackgroundColor, viewBackgroundColor.opacity(0.2)]), startPoint: .top, endPoint: .bottom) :
+                  LinearGradient(gradient: Gradient(colors: [Color.white, viewBackgroundColor.opacity(0.2)]), startPoint: .top, endPoint: .bottom))
     .toast(isPresented: $showToast, message: "New scripture available on Sunday!")
     // Load the data but don't reset the page index when switching back
     // and forth between tabs
     .onAppear(perform: {
       if isDailyReveal && !isSetupDone {
         pageIndex = currentDayOfWeek - 1
+        randomizeGradientColors()
       }
       isSetupDone = true
     })
@@ -159,5 +170,9 @@ struct MemorizeView: View {
     default:
       return "X" // For indices not between 0 and 6
     }
+  }
+
+  private func randomizeGradientColors() {
+    viewBackgroundColor = colors.randomElement() ?? Color.blue
   }
 }


### PR DESCRIPTION
The app needs a little joy in the form of randomized color views. Just a little step in the right direction.


<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Test plan (required)**

Test opening the app in dark and light mode to make sure text still visible and colors cycle through randomly.

Demonstrate the code is solid. Example: Screenshots / videos are helpful if the pull request changes UI.


<img width="470" alt="Screenshot 2024-02-24 at 12 26 45 AM" src="https://github.com/caabernathy/YourWord/assets/691109/0fb5a264-fae9-4933-adbf-3e6686374f6a">

<img width="470" alt="Screenshot 2024-02-24 at 12 27 02 AM" src="https://github.com/caabernathy/YourWord/assets/691109/3dbd131f-16c5-48cc-a317-ab3b192cd9b7">

