### PR TITLE
Add debug vs release config for API endpoint

### DIFF
--- a/YourWord.xcodeproj/project.pbxproj
+++ b/YourWord.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		CB3188812C32745800965152 /* Bible.json in Resources */ = {isa = PBXBuildFile; fileRef = CB3188802C32745800965152 /* Bible.json */; };
 		CB3188832C33B3FA00965152 /* TestamentFilterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB3188822C33B3FA00965152 /* TestamentFilterView.swift */; };
 		CB3188852C33BE9C00965152 /* DeleteButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB3188842C33BE9C00965152 /* DeleteButtonView.swift */; };
+		CB31888B2C3A6D3800965152 /* AppConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB31888A2C3A6D3800965152 /* AppConfig.swift */; };
 		CB3FF8772C041DB800871CCD /* CustomMemorizeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB3FF8762C041DB800871CCD /* CustomMemorizeView.swift */; };
 		CB3FF8792C04251900871CCD /* APIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB3FF8782C04251900871CCD /* APIService.swift */; };
 		CB5314A02B9467610003867A /* PreviewData.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB53149F2B9467610003867A /* PreviewData.swift */; };
@@ -89,6 +90,10 @@
 		CB3188802C32745800965152 /* Bible.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = Bible.json; path = ../../../../../../../../Bible.json; sourceTree = "<group>"; };
 		CB3188822C33B3FA00965152 /* TestamentFilterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestamentFilterView.swift; sourceTree = "<group>"; };
 		CB3188842C33BE9C00965152 /* DeleteButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteButtonView.swift; sourceTree = "<group>"; };
+		CB3188872C3A67C600965152 /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
+		CB3188882C3A686F00965152 /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
+		CB3188892C3A6CF300965152 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		CB31888A2C3A6D3800965152 /* AppConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfig.swift; sourceTree = "<group>"; };
 		CB3FF8762C041DB800871CCD /* CustomMemorizeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomMemorizeView.swift; sourceTree = "<group>"; };
 		CB3FF8782C04251900871CCD /* APIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIService.swift; sourceTree = "<group>"; };
 		CB53149F2B9467610003867A /* PreviewData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewData.swift; sourceTree = "<group>"; };
@@ -153,6 +158,16 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		CB3188862C3A678200965152 /* Configs */ = {
+			isa = PBXGroup;
+			children = (
+				CB3188872C3A67C600965152 /* Debug.xcconfig */,
+				CB3188882C3A686F00965152 /* Release.xcconfig */,
+				CB31888A2C3A6D3800965152 /* AppConfig.swift */,
+			);
+			path = Configs;
+			sourceTree = "<group>";
+		};
 		CB5314A12B9472880003867A /* Previews */ = {
 			isa = PBXGroup;
 			children = (
@@ -219,12 +234,14 @@
 				CBD43F6A2B01DD23003CF5F7 /* YourWordApp.swift */,
 				CB1BA6E82B12D02F004F4CBE /* AppDelegate.swift */,
 				CB07416F2B05D0880000CCCC /* Launch Screen.storyboard */,
+				CB3188892C3A6CF300965152 /* Info.plist */,
 				CBFFAB362B0B4EF100C864C9 /* Extensions */,
 				CBA2C7B02B082D5000A27DE1 /* Managers */,
 				CBD43F962B01DE6B003CF5F7 /* Models */,
 				CBD43F9C2B01E096003CF5F7 /* Views */,
 				CB9432AB2B60C964005F9E48 /* ViewModels */,
 				CBA2C7B32B09B83E00A27DE1 /* Resources */,
+				CB3188862C3A678200965152 /* Configs */,
 				CB5314A12B9472880003867A /* Previews */,
 				CBD43F702B01DD24003CF5F7 /* Assets.xcassets */,
 				CBD43F722B01DD24003CF5F7 /* Preview Content */,
@@ -453,6 +470,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CB9432AF2B64B1D1005F9E48 /* OnboardingManager.swift in Sources */,
+				CB31888B2C3A6D3800965152 /* AppConfig.swift in Sources */,
 				CB9432AD2B60C997005F9E48 /* ScriptureViewModel.swift in Sources */,
 				CB3188852C33BE9C00965152 /* DeleteButtonView.swift in Sources */,
 				CB1394BA2B5B500F0027707D /* ScheduleManager.swift in Sources */,
@@ -648,6 +666,7 @@
 		};
 		CBD43F8E2B01DD24003CF5F7 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = CB3188872C3A67C600965152 /* Debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -657,6 +676,7 @@
 				DEVELOPMENT_TEAM = M2ABT37P66;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = YourWord/Info.plist;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = "Launch Screen";
@@ -677,6 +697,7 @@
 		};
 		CBD43F8F2B01DD24003CF5F7 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = CB3188882C3A686F00965152 /* Release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -686,6 +707,7 @@
 				DEVELOPMENT_TEAM = M2ABT37P66;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = YourWord/Info.plist;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = "Launch Screen";
@@ -706,6 +728,7 @@
 		};
 		CBD43F912B01DD24003CF5F7 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = CB3188872C3A67C600965152 /* Debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -726,6 +749,7 @@
 		};
 		CBD43F922B01DD24003CF5F7 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = CB3188882C3A686F00965152 /* Release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -746,6 +770,7 @@
 		};
 		CBD43F942B01DD24003CF5F7 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = CB3188872C3A67C600965152 /* Debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
@@ -764,6 +789,7 @@
 		};
 		CBD43F952B01DD24003CF5F7 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = CB3188882C3A686F00965152 /* Release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;

--- a/YourWord.xcodeproj/xcshareddata/xcschemes/YourWord.xcscheme
+++ b/YourWord.xcodeproj/xcshareddata/xcschemes/YourWord.xcscheme
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1540"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CBD43F662B01DD23003CF5F7"
+               BuildableName = "YourWord.app"
+               BlueprintName = "YourWord"
+               ReferencedContainer = "container:YourWord.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CBD43F782B01DD24003CF5F7"
+               BuildableName = "YourWordTests.xctest"
+               BlueprintName = "YourWordTests"
+               ReferencedContainer = "container:YourWord.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CBD43F822B01DD24003CF5F7"
+               BuildableName = "YourWordUITests.xctest"
+               BlueprintName = "YourWordUITests"
+               ReferencedContainer = "container:YourWord.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CBD43F662B01DD23003CF5F7"
+            BuildableName = "YourWord.app"
+            BlueprintName = "YourWord"
+            ReferencedContainer = "container:YourWord.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CBD43F662B01DD23003CF5F7"
+            BuildableName = "YourWord.app"
+            BlueprintName = "YourWord"
+            ReferencedContainer = "container:YourWord.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/YourWord/Configs/AppConfig.swift
+++ b/YourWord/Configs/AppConfig.swift
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Christine Abernathy.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import Foundation
+
+struct AppConfig {
+  static let apiBaseURL: String = {
+    guard let apiBaseURL = Bundle.main.infoDictionary?["API_BASE_URL"] as? String else {
+      fatalError("API_BASE_URL not set in plist")
+    }
+    return apiBaseURL
+  }()
+}

--- a/YourWord/Configs/Debug.xcconfig
+++ b/YourWord/Configs/Debug.xcconfig
@@ -1,0 +1,6 @@
+// Copyright (c) Christine Abernathy.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+API_BASE_URL = http:/$()/localhost:3000

--- a/YourWord/Configs/Release.xcconfig
+++ b/YourWord/Configs/Release.xcconfig
@@ -1,0 +1,6 @@
+// Copyright (c) Christine Abernathy.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+API_BASE_URL = https:/$()/yourword-api.fly.dev

--- a/YourWord/Info.plist
+++ b/YourWord/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>API_BASE_URL</key>
+	<string>$(API_BASE_URL)</string>
+</dict>
+</plist>

--- a/YourWord/Managers/APIService.swift
+++ b/YourWord/Managers/APIService.swift
@@ -8,10 +8,24 @@
 import Foundation
 
 class APIService {
+  private let baseURL = URL(string: AppConfig.apiBaseURL)!
+
   static let shared = APIService()
 
   func fetchScripture(book: String, chapter: Int, startVerse: Int, endVerse: Int, completion: @escaping (Result<Scripture, Error>) -> Void) {
-    let url = URL(string: "http://localhost:3000/scripture/reference?book=\(book)&chapter=\(chapter)&startVerse=\(startVerse)&endVerse=\(endVerse)")!
+    let endpoint = baseURL.appendingPathComponent("scripture/reference")
+    var components = URLComponents(url: endpoint, resolvingAgainstBaseURL: true)!
+    components.queryItems = [
+      URLQueryItem(name: "book", value: book),
+      URLQueryItem(name: "chapter", value: String(chapter)),
+      URLQueryItem(name: "startVerse", value: String(startVerse)),
+      URLQueryItem(name: "endVerse", value: String(endVerse))
+    ]
+
+    guard let url = components.url else {
+      completion(.failure(NSError(domain: "InvalidURL", code: 0, userInfo: nil)))
+      return
+    }
 
     URLSession.shared.dataTask(with: url) { data, response, error in
       if let data = data {

--- a/YourWord/Managers/APIService.swift
+++ b/YourWord/Managers/APIService.swift
@@ -11,7 +11,7 @@ class APIService {
   static let shared = APIService()
 
   func fetchScripture(book: String, chapter: Int, startVerse: Int, endVerse: Int, completion: @escaping (Result<Scripture, Error>) -> Void) {
-    let url = URL(string: "http://localhost:3000/scripture?book=\(book)&chapter=\(chapter)&startVerse=\(startVerse)&endVerse=\(endVerse)")!
+    let url = URL(string: "http://localhost:3000/scripture/reference?book=\(book)&chapter=\(chapter)&startVerse=\(startVerse)&endVerse=\(endVerse)")!
 
     URLSession.shared.dataTask(with: url) { data, response, error in
       if let data = data {

--- a/YourWord/Views/Components/ScriptureSelectorView.swift
+++ b/YourWord/Views/Components/ScriptureSelectorView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct ScriptureSelectorView: View {
   var cancelAction: () -> Void
   var submitAction: (String, Int, Int, Int) -> Void
+  @Binding var isLoading: Bool
 
   let bibles = ScriptureManager.shared.loadBible()
 
@@ -65,6 +66,11 @@ struct ScriptureSelectorView: View {
     }
   }
 
+  private func onSubmit() {
+    isLoading = true
+    submitAction(sortedBooks[selectedBookIndex].name, selectedChapter, selectedStartVerse, selectedEndVerse)
+  }
+
   var body: some View {
     let passageTextExtra = selectedEndVerse > selectedStartVerse ? "-\(selectedEndVerse)" : ""
     Group {
@@ -86,14 +92,23 @@ struct ScriptureSelectorView: View {
               .padding()
             Spacer()
             Button(action: {
-              submitAction(sortedBooks[selectedBookIndex].name, selectedChapter, selectedStartVerse, selectedEndVerse)
+              onSubmit()
             }) {
-              Text("GO")
-                .foregroundColor(.white)
-                .padding()
-                .background(Color.blue)
-                .cornerRadius(10)
+              if isLoading {
+                ProgressView()
+                  .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                  .padding([.leading, .trailing], 20)
+                  .padding()
+              } else {
+                Text("GO")
+                  .foregroundColor(.white)
+                  .padding([.leading, .trailing], 17)
+                  .padding()
+              }
             }
+            .background(Color.blue)
+            .cornerRadius(10)
+            .disabled(isLoading)
           }
           .padding()
 
@@ -156,6 +171,18 @@ struct ScriptureSelectorView: View {
 }
 
 
-#Preview {
-  ScriptureSelectorView(cancelAction: {}, submitAction: {_,_,_,_ in })
+#Preview("Default") {
+  ScriptureSelectorView(
+    cancelAction: {},
+    submitAction: {_,_,_,_ in },
+    isLoading: .constant(false)
+  )
+}
+
+#Preview("Loading") {
+  ScriptureSelectorView(
+    cancelAction: {},
+    submitAction: {_,_,_,_ in },
+    isLoading: .constant(true)
+  )
 }

--- a/YourWord/Views/CustomMemorizeView.swift
+++ b/YourWord/Views/CustomMemorizeView.swift
@@ -13,6 +13,7 @@ struct CustomMemorizeView: View {
 
   @State private var showScriptureSelector = false
   @State private var showScriptureDeleteConfirmation = false
+  @State private var isLoading = false
 
   let bibleVersion = SettingsManager.shared.preferredBibleVersion ?? BibleVersion.NIV
 
@@ -47,9 +48,13 @@ struct CustomMemorizeView: View {
       }
     }
     .sheet(isPresented: $showScriptureSelector) {
-      ScriptureSelectorView(cancelAction: handleScriptureSelectorCancel) { book, chapter, startVerse, endVerse in
-        fetchScripture(book: book, chapter: chapter, startVerse: startVerse, endVerse: endVerse)
-      }
+      ScriptureSelectorView(
+        cancelAction: handleScriptureSelectorCancel,
+        submitAction: { book, chapter, startVerse, endVerse in
+          fetchScripture(book: book, chapter: chapter, startVerse: startVerse, endVerse: endVerse)
+        },
+        isLoading: $isLoading
+      )
     }
     .alert(isPresented: $showScriptureDeleteConfirmation) {
       Alert(
@@ -74,9 +79,11 @@ struct CustomMemorizeView: View {
         DispatchQueue.main.async {
           scripture.source = .userDefined
           ScriptureManager.shared.storeScripture(scripture, context: modelContext)
+          isLoading = false
           showScriptureSelector = false
         }
       case .failure(let error):
+        isLoading = false
         print("Error fetching scripture: \(error.localizedDescription)")
       }
     }


### PR DESCRIPTION
Added Xcode config setup so we can switch between localhost and real API endpoint.

<!-- You can skip this if you're fixing a typo. -->

To avoid hard-coding the API endpoints, added info in xcconfig files and set up the schema to pick up the right files. As part of testing this, added an activity indicator that's enabled when fetching scripture.

**Test plan (required)**
1. In the YourWord target, go to the `Run` configuration and switch to Debug.
2. Build and run the app on a Simulator
3. Go to the Your Verses screen and add a custom scripture. Verify that the local server install is activated.
4. Repeat step 2 and check from the server logs (on Fly.io) that that API call is triggered.
