### PR TITLE
Add functionality to search keywords to get scripture

### DIFF
--- a/YourWord.xcodeproj/project.pbxproj
+++ b/YourWord.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		CB003F452B13588C008584F1 /* Date+RawRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB003F442B13588C008584F1 /* Date+RawRepresentable.swift */; };
+		CB0075002C4377A500078EB7 /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0074FF2C4377A500078EB7 /* NetworkManager.swift */; };
 		CB0741702B05D0880000CCCC /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CB07416F2B05D0880000CCCC /* Launch Screen.storyboard */; };
 		CB1394BA2B5B500F0027707D /* ScheduleManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB1394B92B5B500F0027707D /* ScheduleManager.swift */; };
 		CB1394BC2B5CD30A0027707D /* View+toast.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB1394BB2B5CD30A0027707D /* View+toast.swift */; };
@@ -82,6 +83,7 @@
 
 /* Begin PBXFileReference section */
 		CB003F442B13588C008584F1 /* Date+RawRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+RawRepresentable.swift"; sourceTree = "<group>"; };
+		CB0074FF2C4377A500078EB7 /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
 		CB07416F2B05D0880000CCCC /* Launch Screen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
 		CB1394B92B5B500F0027707D /* ScheduleManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleManager.swift; sourceTree = "<group>"; };
 		CB1394BB2B5CD30A0027707D /* View+toast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+toast.swift"; sourceTree = "<group>"; };
@@ -205,6 +207,7 @@
 				CB1394B92B5B500F0027707D /* ScheduleManager.swift */,
 				CB9432AE2B64B1D1005F9E48 /* OnboardingManager.swift */,
 				CB3FF8782C04251900871CCD /* APIService.swift */,
+				CB0074FF2C4377A500078EB7 /* NetworkManager.swift */,
 			);
 			path = Managers;
 			sourceTree = "<group>";
@@ -484,6 +487,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CB0075002C4377A500078EB7 /* NetworkManager.swift in Sources */,
 				CB9432AF2B64B1D1005F9E48 /* OnboardingManager.swift in Sources */,
 				CB31888B2C3A6D3800965152 /* AppConfig.swift in Sources */,
 				CB9432AD2B60C997005F9E48 /* ScriptureViewModel.swift in Sources */,

--- a/YourWord.xcodeproj/project.pbxproj
+++ b/YourWord.xcodeproj/project.pbxproj
@@ -22,6 +22,11 @@
 		CB3188832C33B3FA00965152 /* TestamentFilterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB3188822C33B3FA00965152 /* TestamentFilterView.swift */; };
 		CB3188852C33BE9C00965152 /* DeleteButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB3188842C33BE9C00965152 /* DeleteButtonView.swift */; };
 		CB31888B2C3A6D3800965152 /* AppConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB31888A2C3A6D3800965152 /* AppConfig.swift */; };
+		CB31888D2C3C280500965152 /* SearchBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB31888C2C3C280500965152 /* SearchBarView.swift */; };
+		CB31888F2C40F4CC00965152 /* ScriptureAddView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB31888E2C40F4CC00965152 /* ScriptureAddView.swift */; };
+		CB3188912C4233A000965152 /* ScriptureSearchResultsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB3188902C4233A000965152 /* ScriptureSearchResultsView.swift */; };
+		CB3188932C42589900965152 /* SearchResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB3188922C42589900965152 /* SearchResult.swift */; };
+		CB3188952C42657E00965152 /* ScriptureRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB3188942C42657E00965152 /* ScriptureRowView.swift */; };
 		CB3FF8772C041DB800871CCD /* CustomMemorizeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB3FF8762C041DB800871CCD /* CustomMemorizeView.swift */; };
 		CB3FF8792C04251900871CCD /* APIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB3FF8782C04251900871CCD /* APIService.swift */; };
 		CB5314A02B9467610003867A /* PreviewData.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB53149F2B9467610003867A /* PreviewData.swift */; };
@@ -94,6 +99,11 @@
 		CB3188882C3A686F00965152 /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		CB3188892C3A6CF300965152 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		CB31888A2C3A6D3800965152 /* AppConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfig.swift; sourceTree = "<group>"; };
+		CB31888C2C3C280500965152 /* SearchBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBarView.swift; sourceTree = "<group>"; };
+		CB31888E2C40F4CC00965152 /* ScriptureAddView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptureAddView.swift; sourceTree = "<group>"; };
+		CB3188902C4233A000965152 /* ScriptureSearchResultsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptureSearchResultsView.swift; sourceTree = "<group>"; };
+		CB3188922C42589900965152 /* SearchResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResult.swift; sourceTree = "<group>"; };
+		CB3188942C42657E00965152 /* ScriptureRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptureRowView.swift; sourceTree = "<group>"; };
 		CB3FF8762C041DB800871CCD /* CustomMemorizeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomMemorizeView.swift; sourceTree = "<group>"; };
 		CB3FF8782C04251900871CCD /* APIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIService.swift; sourceTree = "<group>"; };
 		CB53149F2B9467610003867A /* PreviewData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewData.swift; sourceTree = "<group>"; };
@@ -283,6 +293,7 @@
 				CBF969132B14A87D003D90FE /* Passage.swift */,
 				CBD43F972B01DEA2003CF5F7 /* Scripture.swift */,
 				CBF969112B14A851003D90FE /* Translation.swift */,
+				CB3188922C42589900965152 /* SearchResult.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -298,6 +309,8 @@
 				CBAC66642B0DB7A60044BBE7 /* ScripturesListView.swift */,
 				CBF969172B158429003D90FE /* ScriptureRevealView.swift */,
 				CB3FF8762C041DB800871CCD /* CustomMemorizeView.swift */,
+				CB31888E2C40F4CC00965152 /* ScriptureAddView.swift */,
+				CB3188902C4233A000965152 /* ScriptureSearchResultsView.swift */,
 				CB3188722C2932E200965152 /* PresetMemorizeView.swift */,
 			);
 			path = Views;
@@ -316,6 +329,8 @@
 				CB9432B42B8AA7B7005F9E48 /* ScriptureSelectorView.swift */,
 				CB91397C2BA1B09E00C8D8B0 /* ToolbarLinkView.swift */,
 				CB3188822C33B3FA00965152 /* TestamentFilterView.swift */,
+				CB31888C2C3C280500965152 /* SearchBarView.swift */,
+				CB3188942C42657E00965152 /* ScriptureRowView.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -480,10 +495,13 @@
 				CBF969212B15B300003D90FE /* DayOfWeekLabelView.swift in Sources */,
 				CBAC66612B0DB5C30044BBE7 /* MainTabView.swift in Sources */,
 				CBD43FA12B01E189003CF5F7 /* ScriptureView.swift in Sources */,
+				CB3188952C42657E00965152 /* ScriptureRowView.swift in Sources */,
 				CB3188732C2932E200965152 /* PresetMemorizeView.swift in Sources */,
+				CB31888F2C40F4CC00965152 /* ScriptureAddView.swift in Sources */,
 				CBAC66672B12AFD60044BBE7 /* NotificationManager.swift in Sources */,
 				CB1BA6E92B12D02F004F4CBE /* AppDelegate.swift in Sources */,
 				CB003F452B13588C008584F1 /* Date+RawRepresentable.swift in Sources */,
+				CB31888D2C3C280500965152 /* SearchBarView.swift in Sources */,
 				CB3188792C313F4E00965152 /* SaveButtonView.swift in Sources */,
 				CBD43F9E2B01E105003CF5F7 /* MemorizeView.swift in Sources */,
 				CBAC66632B0DB75D0044BBE7 /* SettingsView.swift in Sources */,
@@ -496,6 +514,7 @@
 				CB31887B2C3262C700965152 /* Book.swift in Sources */,
 				CBD43F6B2B01DD23003CF5F7 /* YourWordApp.swift in Sources */,
 				CBF969232B15B3BF003D90FE /* DayOfWeekButtonView.swift in Sources */,
+				CB3188912C4233A000965152 /* ScriptureSearchResultsView.swift in Sources */,
 				CB9432B12B64B309005F9E48 /* OnboardingView.swift in Sources */,
 				CB3188832C33B3FA00965152 /* TestamentFilterView.swift in Sources */,
 				CB9432B32B8AA760005F9E48 /* Bible.swift in Sources */,
@@ -506,6 +525,7 @@
 				CB1394BC2B5CD30A0027707D /* View+toast.swift in Sources */,
 				CB31887D2C3270BD00965152 /* BibleVersion.swift in Sources */,
 				CB5314A32B9472F80003867A /* PreviewModelContainer.swift in Sources */,
+				CB3188932C42589900965152 /* SearchResult.swift in Sources */,
 				CBAC66652B0DB7A60044BBE7 /* ScripturesListView.swift in Sources */,
 				CBD43F982B01DEA2003CF5F7 /* Scripture.swift in Sources */,
 				CBF969122B14A851003D90FE /* Translation.swift in Sources */,

--- a/YourWord/Managers/APIService.swift
+++ b/YourWord/Managers/APIService.swift
@@ -40,4 +40,37 @@ class APIService {
       }
     }.resume()
   }
+
+  func searchScriptures(version: BibleVersion, text: String, completion: @escaping (Result<[SearchResultScripture], Error>) -> Void) {
+    let endpoint = baseURL.appendingPathComponent("scripture/search")
+    var components = URLComponents(url: endpoint, resolvingAgainstBaseURL: true)!
+    components.queryItems = [
+      URLQueryItem(name: "version", value: version.rawValue),
+      URLQueryItem(name: "text", value: text)
+    ]
+
+    guard let url = components.url else {
+      completion(.failure(NSError(domain: "InvalidURL", code: 0, userInfo: nil)))
+      return
+    }
+
+    URLSession.shared.dataTask(with: url) { data, response, error in
+      if let error = error {
+        completion(.failure(error))
+        return
+      }
+
+      guard let data = data else {
+        completion(.failure(NSError(domain: "NoData", code: 0, userInfo: nil)))
+        return
+      }
+
+      do {
+        let searchResults = try JSONDecoder().decode([SearchResultScripture].self, from: data)
+        completion(.success(searchResults))
+      } catch {
+        completion(.failure(error))
+      }
+    }.resume()
+  }
 }

--- a/YourWord/Managers/APIService.swift
+++ b/YourWord/Managers/APIService.swift
@@ -7,12 +7,49 @@
 
 import Foundation
 
+enum APIError: Error {
+  case noInternetConnection
+  case invalidURL
+  case serverError(String)
+
+  var localizedDescription: String {
+    switch self {
+    case .noInternetConnection:
+      return "You don't have an internet connection so we can't fetch scriptures. Please try again later."
+    case .invalidURL:
+      return "There was a problem with the request. Please try again later."
+    case .serverError(let message):
+      return "An error occurred: \(message)"
+    }
+  }
+}
+
 class APIService {
   private let baseURL = URL(string: AppConfig.apiBaseURL)!
+  private let networkManager = NetworkManager.shared
 
   static let shared = APIService()
 
-  func fetchScripture(book: String, chapter: Int, startVerse: Int, endVerse: Int, completion: @escaping (Result<Scripture, Error>) -> Void) {
+  private func fetchData<T: Decodable>(from url: URL) async throws -> T {
+    guard networkManager.isConnected else {
+      throw APIError.noInternetConnection
+    }
+
+    let (data, response) = try await URLSession.shared.data(from: url)
+
+    guard let httpResponse = response as? HTTPURLResponse,
+          (200...299).contains(httpResponse.statusCode) else {
+      throw APIError.serverError("Server returned an invalid response.")
+    }
+
+    do {
+      return try JSONDecoder().decode(T.self, from: data)
+    } catch {
+      throw APIError.serverError("Failed to process the response: \(error.localizedDescription)")
+    }
+  }
+
+  func fetchScripture(book: String, chapter: Int, startVerse: Int, endVerse: Int) async throws -> Scripture {
     let endpoint = baseURL.appendingPathComponent("scripture/reference")
     var components = URLComponents(url: endpoint, resolvingAgainstBaseURL: true)!
     components.queryItems = [
@@ -23,25 +60,13 @@ class APIService {
     ]
 
     guard let url = components.url else {
-      completion(.failure(NSError(domain: "InvalidURL", code: 0, userInfo: nil)))
-      return
+      throw APIError.invalidURL
     }
 
-    URLSession.shared.dataTask(with: url) { data, response, error in
-      if let data = data {
-        do {
-          let scripture = try JSONDecoder().decode(Scripture.self, from: data)
-          completion(.success(scripture))
-        } catch {
-          completion(.failure(error))
-        }
-      } else if let error = error {
-        completion(.failure(error))
-      }
-    }.resume()
+    return try await fetchData(from: url)
   }
 
-  func searchScriptures(version: BibleVersion, text: String, completion: @escaping (Result<[SearchResultScripture], Error>) -> Void) {
+  func searchScriptures(version: BibleVersion, text: String) async throws -> [SearchResultScripture] {
     let endpoint = baseURL.appendingPathComponent("scripture/search")
     var components = URLComponents(url: endpoint, resolvingAgainstBaseURL: true)!
     components.queryItems = [
@@ -50,27 +75,9 @@ class APIService {
     ]
 
     guard let url = components.url else {
-      completion(.failure(NSError(domain: "InvalidURL", code: 0, userInfo: nil)))
-      return
+      throw APIError.invalidURL
     }
 
-    URLSession.shared.dataTask(with: url) { data, response, error in
-      if let error = error {
-        completion(.failure(error))
-        return
-      }
-
-      guard let data = data else {
-        completion(.failure(NSError(domain: "NoData", code: 0, userInfo: nil)))
-        return
-      }
-
-      do {
-        let searchResults = try JSONDecoder().decode([SearchResultScripture].self, from: data)
-        completion(.success(searchResults))
-      } catch {
-        completion(.failure(error))
-      }
-    }.resume()
+    return try await fetchData(from: url)
   }
 }

--- a/YourWord/Managers/NetworkManager.swift
+++ b/YourWord/Managers/NetworkManager.swift
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Christine Abernathy.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import Foundation
+import Network
+import Observation
+
+@Observable
+class NetworkManager {
+  static let shared = NetworkManager()
+  private let monitor = NWPathMonitor()
+  private let queue = DispatchQueue(label: "NetworkMonitor")
+  var isConnected = false
+
+  private init() {
+    monitor.pathUpdateHandler = { [weak self] path in
+      DispatchQueue.main.async {
+        self?.isConnected = path.status == .satisfied
+      }
+    }
+    monitor.start(queue: queue)
+  }
+}

--- a/YourWord/Models/SearchResult.swift
+++ b/YourWord/Models/SearchResult.swift
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) Christine Abernathy.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import Foundation
+
+struct SearchResultPassage: Codable, CustomStringConvertible {
+  var book: String
+  var chapter: Int
+  var startVerse: Int
+  var endVerse: Int
+
+  var description: String {
+    if startVerse == endVerse {
+      return "\(book) \(chapter):\(startVerse)"
+    } else {
+      return "\(book) \(chapter):\(startVerse)-\(endVerse)"
+    }
+  }
+}
+
+struct SearchResultTranslation: Codable {
+  var name: BibleVersion
+  var text: String
+}
+
+struct SearchResultScripture: Codable, Identifiable {
+  let id: UUID
+  var passage: SearchResultPassage
+  var translations: [SearchResultTranslation]
+
+  init(passage: SearchResultPassage, translations: [SearchResultTranslation]) {
+    self.id = UUID()
+    self.passage = passage
+    self.translations = translations
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case passage, translations
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.id = UUID()
+    self.passage = try container.decode(SearchResultPassage.self, forKey: .passage)
+    self.translations = try container.decode([SearchResultTranslation].self, forKey: .translations)
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(passage, forKey: .passage)
+    try container.encode(translations, forKey: .translations)
+  }
+}

--- a/YourWord/Previews/PreviewData.swift
+++ b/YourWord/Previews/PreviewData.swift
@@ -77,3 +77,24 @@ struct PreviewData {
     Bible(version: .KJV, books: bibleBooks)
   ]
 }
+
+extension PreviewData {
+  static var searchResultScriptures: [SearchResultScripture] {
+    return scriptures.map { scripture in
+      SearchResultScripture(
+        passage: SearchResultPassage(
+          book: scripture.passage.book,
+          chapter: scripture.passage.chapter,
+          startVerse: scripture.passage.startVerse,
+          endVerse: scripture.passage.endVerse
+        ),
+        translations: scripture.translations.map { translation in
+          SearchResultTranslation(
+            name: translation.name,
+            text: translation.text
+          )
+        }
+      )
+    }
+  }
+}

--- a/YourWord/ViewModels/ScriptureViewModel.swift
+++ b/YourWord/ViewModels/ScriptureViewModel.swift
@@ -11,7 +11,7 @@ import Foundation
   private var scripture: Scripture
 
   var memoryTexts: [String] = []
-  var memorySources: [String] = []
+  var memoryReferences: [String] = []
 
   init(scripture: Scripture) {
     self.scripture = scripture
@@ -21,9 +21,9 @@ import Foundation
     guard
       let scriptureVersion = scripture.version(for: bibleVersion) else { return false }
     let maskedTexts = maskScriptureText(scriptureVersion)
-    let maskedSources = maskSriptureReference(scripture.passage)
+    let maskedReferences = maskSriptureReference(scripture.passage)
     memoryTexts = Array(maskedTexts.prefix(numberOfDaysToShow))
-    memorySources = Array(maskedSources.prefix(numberOfDaysToShow))
+    memoryReferences = Array(maskedReferences.prefix(numberOfDaysToShow))
     return true
   }
 
@@ -46,10 +46,10 @@ import Foundation
   }
 
   func maskSriptureReference(_ passage: Passage) -> [String] {
-    var replacedSources: [String] = []
-    // Mask source
+    var replacedReferences: [String] = []
+    // Mask Reference
     for i in 0..<ScriptureManager.shared.memorizeCount {
-      // Modifiying source
+      // Modifiying reference
       if !passage.maskingKey.isEmpty && passage.maskingKey[i] {
         // Switch up the masking, last element will be msked
         let lastRound = (i == ScriptureManager.shared.memorizeCount - 1)
@@ -58,20 +58,20 @@ import Foundation
         // Odd, mask chapter and verses
         let modifiedChapter = lastRound || (i % 2 != 0) ? replaceWithUnderscore(text: String(passage.chapter)) : String(passage.chapter)
         let modifiedVerses = lastRound || (i % 2 != 0) ? replaceWithUnderscore(text: passage.verses) : passage.verses
-        replacedSources.append(formatSource(book: modifiedBook, chapter: modifiedChapter, verses: modifiedVerses))
+        replacedReferences.append(formatReference(book: modifiedBook, chapter: modifiedChapter, verses: modifiedVerses))
       } else {
-        // Source not being modified
-        replacedSources.append(formatSource(book: passage.book, chapter: String(passage.chapter), verses: passage.verses))
+        // Reference not being modified
+        replacedReferences.append(formatReference(book: passage.book, chapter: String(passage.chapter), verses: passage.verses))
       }
     }
-    return replacedSources
+    return replacedReferences
   }
 
   private func replaceWithUnderscore(text: String) -> String {
     return text.replacingOccurrences(of: "\\w", with: "_", options: .regularExpression)
   }
 
-  private func formatSource(book: String, chapter: String, verses: String) -> String {
+  private func formatReference(book: String, chapter: String, verses: String) -> String {
     return "\(book) \(chapter):\(verses)"
   }
 }

--- a/YourWord/Views/Components/ScriptureRowView.swift
+++ b/YourWord/Views/Components/ScriptureRowView.swift
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Christine Abernathy.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import SwiftUI
+
+struct ScriptureRowView: View {
+  let scripture: SearchResultScripture
+  let isTapped: Bool
+  
+  var body: some View {
+    VStack(alignment: .leading) {
+      Text("\(scripture.passage) \(scripture.translations.first?.name.rawValue ?? "")")
+        .font(.headline)
+      Text(scripture.translations.first?.text ?? "")
+        .font(.subheadline)
+        .lineLimit(2)
+    }
+    .padding(.vertical, 8)
+    .background(
+      RoundedRectangle(cornerRadius: 8)
+        .fill(isTapped ? Color.blue.opacity(0.1) : Color.clear)
+    )
+    .animation(.easeInOut(duration: 0.3), value: isTapped)
+  }
+}
+
+#Preview("Off") {
+  let _ = previewContainer
+  let scriptures = PreviewData.searchResultScriptures
+  return ScriptureRowView(scripture: scriptures[0], isTapped: false)
+}
+
+#Preview("On") {
+  let _ = previewContainer
+  let scriptures = PreviewData.searchResultScriptures
+  return ScriptureRowView(scripture: scriptures[0], isTapped: true)
+}
+

--- a/YourWord/Views/Components/ScriptureSelectorView.swift
+++ b/YourWord/Views/Components/ScriptureSelectorView.swift
@@ -15,7 +15,7 @@ class ScriptureSelectionState {
   var selectedEndVerse: Int = 1
   var isAlphabeticallySorted: Bool = false
   var selectedTestamentFilter: TestamentFilter = .all
-  
+
   init(selectedBookIndex: Int = 0, selectedChapter: Int = 1, selectedStartVerse: Int = 1, selectedEndVerse: Int = 1, isAlphabeticallySorted: Bool = false, selectedTestamentFilter: TestamentFilter = .all) {
     self.selectedBookIndex = selectedBookIndex
     self.selectedChapter = selectedChapter
@@ -30,16 +30,16 @@ struct ScriptureSelectorView: View {
   @Binding var isLoading: Bool
   @Binding var state: ScriptureSelectionState
   var submitAction: (String, Int, Int, Int) -> Void
-  
+
   let bibles = ScriptureManager.shared.loadBible()
-  
+
   let bibleVersion = SettingsManager.shared.preferredBibleVersion ?? BibleVersion.NIV
-  
+
   @State private var bibleBooks: [Book] = []
   @State private var sortedBooks: [Book] = []
   @State private var numberOfChaptersInBook = 0
   @State private var numberOfVersesInChapter = 0
-  
+
   private func loadBibleBooks(for version: BibleVersion) {
     let versionBible = bibles.first { $0.version == bibleVersion }
     if let versionBible = versionBible {
@@ -48,37 +48,37 @@ struct ScriptureSelectorView: View {
     setupBibleBooks()
     setupChapterVerses()
   }
-  
+
   private func setupBibleBooks() {
     let filteredByTestament = filterBooks(bibleBooks)
     let sortedByName = filteredByTestament.sorted()
     let sortedByOrder = filteredByTestament.sorted { $0.order < $1.order }
     sortedBooks = state.isAlphabeticallySorted ? sortedByName : sortedByOrder
   }
-  
+
   private func setupChapterVerses() {
     let selectedBook = sortedBooks[state.selectedBookIndex]
     numberOfChaptersInBook = selectedBook.numberOfChapters
     numberOfVersesInChapter = selectedBook.chaptersAndVerses[state.selectedChapter] ?? 0
   }
-  
+
   private func onSortFilterChange() {
     state.selectedBookIndex = 0
     setupBibleBooks()
     onSelectedBookChange()
   }
-  
+
   private func onSelectedBookChange() {
     state.selectedChapter = 1
     onSelectedChapterChange()
   }
-  
+
   private func onSelectedChapterChange() {
     state.selectedStartVerse = 1
     state.selectedEndVerse = 1
     setupChapterVerses()
   }
-  
+
   private func filterBooks(_ books: [Book]) -> [Book] {
     switch state.selectedTestamentFilter {
     case .all:
@@ -87,12 +87,11 @@ struct ScriptureSelectorView: View {
       return books.filter { $0.testament == testament }
     }
   }
-  
+
   private func onSubmit() {
-    isLoading = true
     submitAction(sortedBooks[state.selectedBookIndex].name, state.selectedChapter, state.selectedStartVerse, state.selectedEndVerse)
   }
-  
+
   var body: some View {
     let passageTextExtra = state.selectedEndVerse > state.selectedStartVerse ? "-\(state.selectedEndVerse)" : ""
     Group {
@@ -123,8 +122,8 @@ struct ScriptureSelectorView: View {
             .disabled(isLoading)
           }
           .padding(.horizontal)
-          
-          
+
+
           HStack {
             Picker("Book", selection: $state.selectedBookIndex) {
               ForEach(0..<sortedBooks.count, id: \.self) { index in
@@ -158,12 +157,12 @@ struct ScriptureSelectorView: View {
           .pickerStyle(.wheel)
           .frame(height: 200)
           .padding(.top, -20)
-          
+
           TestamentFilterView(selectedFilter: $state.selectedTestamentFilter)
             .onChange(of: state.selectedTestamentFilter) {
               onSortFilterChange()
             }
-          
+
           Toggle(isOn: $state.isAlphabeticallySorted) {
             Text("Sort Books Alphabetically")
           }
@@ -171,7 +170,7 @@ struct ScriptureSelectorView: View {
           .onChange(of: state.isAlphabeticallySorted) {
             onSortFilterChange()
           }
-          
+
           Spacer()
         }
       } else {

--- a/YourWord/Views/Components/ScriptureSelectorView.swift
+++ b/YourWord/Views/Components/ScriptureSelectorView.swift
@@ -7,76 +7,99 @@
 
 import SwiftUI
 
+@Observable
+class ScriptureSelectionState {
+  var selectedBookIndex: Int = 0
+  var selectedChapter: Int = 1
+  var selectedStartVerse: Int = 1
+  var selectedEndVerse: Int = 1
+  var isAlphabeticallySorted: Bool = false
+  var selectedTestamentFilter: TestamentFilter = .all
+  
+  init(selectedBookIndex: Int = 0, selectedChapter: Int = 1, selectedStartVerse: Int = 1, selectedEndVerse: Int = 1, isAlphabeticallySorted: Bool = false, selectedTestamentFilter: TestamentFilter = .all) {
+    self.selectedBookIndex = selectedBookIndex
+    self.selectedChapter = selectedChapter
+    self.selectedStartVerse = selectedStartVerse
+    self.selectedEndVerse = selectedEndVerse
+    self.isAlphabeticallySorted = isAlphabeticallySorted
+    self.selectedTestamentFilter = selectedTestamentFilter
+  }
+}
+
 struct ScriptureSelectorView: View {
   @Binding var isLoading: Bool
+  @Binding var state: ScriptureSelectionState
   var submitAction: (String, Int, Int, Int) -> Void
-
+  
   let bibles = ScriptureManager.shared.loadBible()
-
+  
   let bibleVersion = SettingsManager.shared.preferredBibleVersion ?? BibleVersion.NIV
-
+  
   @State private var bibleBooks: [Book] = []
   @State private var sortedBooks: [Book] = []
   @State private var numberOfChaptersInBook = 0
   @State private var numberOfVersesInChapter = 0
-  @State private var selectedBookIndex = 0
-  @State private var selectedChapter = 1
-  @State private var selectedStartVerse = 1
-  @State private var selectedEndVerse = 1
-  @State private var isAlphabeticallySorted = false
-  @State private var selectedTestamentFilter: TestamentFilter = .all
-
+  
   private func loadBibleBooks(for version: BibleVersion) {
     let versionBible = bibles.first { $0.version == bibleVersion }
     if let versionBible = versionBible {
       bibleBooks = versionBible.books
     }
-    displayBibleBooks()
+    setupBibleBooks()
+    setupChapterVerses()
   }
-
-  private func displayBibleBooks() {
-    selectedBookIndex = 0
+  
+  private func setupBibleBooks() {
     let filteredByTestament = filterBooks(bibleBooks)
     let sortedByName = filteredByTestament.sorted()
     let sortedByOrder = filteredByTestament.sorted { $0.order < $1.order }
-    sortedBooks = isAlphabeticallySorted ? sortedByName : sortedByOrder
+    sortedBooks = state.isAlphabeticallySorted ? sortedByName : sortedByOrder
+  }
+  
+  private func setupChapterVerses() {
+    let selectedBook = sortedBooks[state.selectedBookIndex]
+    numberOfChaptersInBook = selectedBook.numberOfChapters
+    numberOfVersesInChapter = selectedBook.chaptersAndVerses[state.selectedChapter] ?? 0
+  }
+  
+  private func onSortFilterChange() {
+    state.selectedBookIndex = 0
+    setupBibleBooks()
     onSelectedBookChange()
   }
-
+  
   private func onSelectedBookChange() {
-    selectedChapter = 1
+    state.selectedChapter = 1
     onSelectedChapterChange()
   }
-
+  
   private func onSelectedChapterChange() {
-    selectedStartVerse = 1
-    selectedEndVerse = 1
-    let selectedBook = sortedBooks[selectedBookIndex]
-    numberOfChaptersInBook = selectedBook.numberOfChapters
-    numberOfVersesInChapter = selectedBook.chaptersAndVerses[selectedChapter] ?? 0
+    state.selectedStartVerse = 1
+    state.selectedEndVerse = 1
+    setupChapterVerses()
   }
-
+  
   private func filterBooks(_ books: [Book]) -> [Book] {
-    switch selectedTestamentFilter {
+    switch state.selectedTestamentFilter {
     case .all:
       return books
     case .testament(let testament):
       return books.filter { $0.testament == testament }
     }
   }
-
+  
   private func onSubmit() {
     isLoading = true
-    submitAction(sortedBooks[selectedBookIndex].name, selectedChapter, selectedStartVerse, selectedEndVerse)
+    submitAction(sortedBooks[state.selectedBookIndex].name, state.selectedChapter, state.selectedStartVerse, state.selectedEndVerse)
   }
-
+  
   var body: some View {
-    let passageTextExtra = selectedEndVerse > selectedStartVerse ? "-\(selectedEndVerse)" : ""
+    let passageTextExtra = state.selectedEndVerse > state.selectedStartVerse ? "-\(state.selectedEndVerse)" : ""
     Group {
-      if sortedBooks.count > 0 {
+      if sortedBooks.count > 0 && numberOfChaptersInBook > 0 {
         VStack(spacing: 10) {
           HStack {
-            Text("\(sortedBooks[selectedBookIndex].name) \(selectedChapter):\(selectedStartVerse)\(passageTextExtra)")
+            Text("\(sortedBooks[state.selectedBookIndex].name) \(state.selectedChapter):\(state.selectedStartVerse)\(passageTextExtra)")
               .font(.title2)
               .padding()
             Spacer()
@@ -100,55 +123,55 @@ struct ScriptureSelectorView: View {
             .disabled(isLoading)
           }
           .padding(.horizontal)
-
-
+          
+          
           HStack {
-            Picker("Book", selection: $selectedBookIndex) {
+            Picker("Book", selection: $state.selectedBookIndex) {
               ForEach(0..<sortedBooks.count, id: \.self) { index in
                 Text(sortedBooks[index].name).tag(index)
               }
             }
-            Picker("Chapter", selection: $selectedChapter) {
+            Picker("Chapter", selection: $state.selectedChapter) {
               ForEach(1...numberOfChaptersInBook, id: \.self) { chapter in
                 Text("\(chapter)").tag(chapter)
               }
             }
-            Picker("Starting Verse", selection: $selectedStartVerse) {
+            Picker("Starting Verse", selection: $state.selectedStartVerse) {
               ForEach(1...numberOfVersesInChapter, id: \.self) { verse in
                 Text("\(verse)").tag(verse)
               }
             }
-            Picker("Ending Verse", selection: $selectedEndVerse) {
-              ForEach(selectedStartVerse...numberOfVersesInChapter, id: \.self) { verse in
+            Picker("Ending Verse", selection: $state.selectedEndVerse) {
+              ForEach(state.selectedStartVerse...numberOfVersesInChapter, id: \.self) { verse in
                 Text("\(verse)").tag(verse)
               }
             }
           }
-          .onChange(of: selectedBookIndex) {
+          .onChange(of: state.selectedBookIndex) {
             // Reset chapter and verse selections when the book changes
             onSelectedBookChange()
           }
-          .onChange(of: selectedChapter) {
+          .onChange(of: state.selectedChapter) {
             // Reset verse selections when the chapter changes
             onSelectedChapterChange()
           }
           .pickerStyle(.wheel)
           .frame(height: 200)
           .padding(.top, -20)
-
-          TestamentFilterView(selectedFilter: $selectedTestamentFilter)
-            .onChange(of: selectedTestamentFilter) {
-              displayBibleBooks()
+          
+          TestamentFilterView(selectedFilter: $state.selectedTestamentFilter)
+            .onChange(of: state.selectedTestamentFilter) {
+              onSortFilterChange()
             }
-
-          Toggle(isOn: $isAlphabeticallySorted) {
+          
+          Toggle(isOn: $state.isAlphabeticallySorted) {
             Text("Sort Books Alphabetically")
           }
           .padding(.horizontal)
-          .onChange(of: isAlphabeticallySorted) {
-            displayBibleBooks()
+          .onChange(of: state.isAlphabeticallySorted) {
+            onSortFilterChange()
           }
-
+          
           Spacer()
         }
       } else {
@@ -163,15 +186,26 @@ struct ScriptureSelectorView: View {
 
 
 #Preview("Default") {
-  ScriptureSelectorView(
+  @State var previewState = ScriptureSelectionState()
+  return ScriptureSelectorView(
     isLoading: .constant(false),
+    state: $previewState,
     submitAction: {_,_,_,_ in }
   )
 }
 
 #Preview("Loading") {
-  ScriptureSelectorView(
+  @State var previewState = ScriptureSelectionState(
+    selectedBookIndex: 2,
+    selectedChapter: 3,
+    selectedStartVerse: 1,
+    selectedEndVerse: 5,
+    isAlphabeticallySorted: true,
+    selectedTestamentFilter: .testament(.old)
+  )
+  return ScriptureSelectorView(
     isLoading: .constant(true),
+    state: $previewState,
     submitAction: {_,_,_,_ in }
   )
 }

--- a/YourWord/Views/Components/ScriptureSelectorView.swift
+++ b/YourWord/Views/Components/ScriptureSelectorView.swift
@@ -8,9 +8,8 @@
 import SwiftUI
 
 struct ScriptureSelectorView: View {
-  var cancelAction: () -> Void
-  var submitAction: (String, Int, Int, Int) -> Void
   @Binding var isLoading: Bool
+  var submitAction: (String, Int, Int, Int) -> Void
 
   let bibles = ScriptureManager.shared.loadBible()
 
@@ -75,17 +74,7 @@ struct ScriptureSelectorView: View {
     let passageTextExtra = selectedEndVerse > selectedStartVerse ? "-\(selectedEndVerse)" : ""
     Group {
       if sortedBooks.count > 0 {
-        VStack {
-          HStack {
-            Spacer()
-            Button(action: cancelAction) {
-              Image(systemName: "xmark")
-                .foregroundColor(.gray)
-                .padding()
-            }
-          }
-          Spacer()
-
+        VStack(spacing: 10) {
           HStack {
             Text("\(sortedBooks[selectedBookIndex].name) \(selectedChapter):\(selectedStartVerse)\(passageTextExtra)")
               .font(.title2)
@@ -110,7 +99,8 @@ struct ScriptureSelectorView: View {
             .cornerRadius(10)
             .disabled(isLoading)
           }
-          .padding()
+          .padding(.horizontal)
+
 
           HStack {
             Picker("Book", selection: $selectedBookIndex) {
@@ -142,8 +132,9 @@ struct ScriptureSelectorView: View {
             // Reset verse selections when the chapter changes
             onSelectedChapterChange()
           }
-          .padding()
           .pickerStyle(.wheel)
+          .frame(height: 200)
+          .padding(.top, -20)
 
           TestamentFilterView(selectedFilter: $selectedTestamentFilter)
             .onChange(of: selectedTestamentFilter) {
@@ -153,7 +144,7 @@ struct ScriptureSelectorView: View {
           Toggle(isOn: $isAlphabeticallySorted) {
             Text("Sort Books Alphabetically")
           }
-          .padding()
+          .padding(.horizontal)
           .onChange(of: isAlphabeticallySorted) {
             displayBibleBooks()
           }
@@ -173,16 +164,14 @@ struct ScriptureSelectorView: View {
 
 #Preview("Default") {
   ScriptureSelectorView(
-    cancelAction: {},
-    submitAction: {_,_,_,_ in },
-    isLoading: .constant(false)
+    isLoading: .constant(false),
+    submitAction: {_,_,_,_ in }
   )
 }
 
 #Preview("Loading") {
   ScriptureSelectorView(
-    cancelAction: {},
-    submitAction: {_,_,_,_ in },
-    isLoading: .constant(true)
+    isLoading: .constant(true),
+    submitAction: {_,_,_,_ in }
   )
 }

--- a/YourWord/Views/Components/ScriptureView.swift
+++ b/YourWord/Views/Components/ScriptureView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct ScriptureView: View {
   var text: String
-  var source: String
+  var reference: String
 
   var body: some View {
     VStack(alignment: .leading) {
@@ -17,7 +17,7 @@ struct ScriptureView: View {
         .font(/*@START_MENU_TOKEN@*/.title/*@END_MENU_TOKEN@*/)
         .padding()
         .minimumScaleFactor(0.5)
-      Text(source)
+      Text(reference)
         .padding()
     }
     .padding()
@@ -29,5 +29,5 @@ struct ScriptureView: View {
 }
 
 #Preview {
-  ScriptureView(text: "Thy word is a lamp unto my feet, and a light unto my path.", source: "Psalm 119:105 KJV")
+  ScriptureView(text: "Thy word is a lamp unto my feet, and a light unto my path.", reference: "Psalm 119:105 KJV")
 }

--- a/YourWord/Views/Components/SearchBarView.swift
+++ b/YourWord/Views/Components/SearchBarView.swift
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) Christine Abernathy.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import SwiftUI
+
+struct SearchBarView: View {
+  @Binding var isLoading: Bool
+  var searchAction: (String) -> Void
+
+  @State private var searchText: String = ""
+  
+  var body: some View {
+    HStack {
+      TextField("Enter passage, keyword...", text: $searchText)
+        .padding(10)
+        .background(Color(.systemGray6))
+        .cornerRadius(8)
+
+      Button(action: {
+        if !isLoading {
+          searchAction(searchText)
+        }
+      }) {
+        Group {
+          if isLoading {
+            ProgressView()
+              .progressViewStyle(CircularProgressViewStyle(tint: .white))
+          } else {
+            Image(systemName: "magnifyingglass")
+          }
+        }
+        .frame(width: 20, height: 20)
+        .foregroundColor(.white)
+      }
+      .frame(width: 44, height: 44)
+      .background(Color.blue)
+      .cornerRadius(8)
+      .disabled(isLoading)
+    }
+    .padding()
+  }
+}
+
+#Preview("Default") {
+  SearchBarView(
+    isLoading: .constant(false),
+    searchAction: {_ in }
+  )
+}
+
+#Preview("Searching") {
+  SearchBarView(
+    isLoading: .constant(true),
+    searchAction: {_ in }
+  )
+}

--- a/YourWord/Views/Components/SearchBarView.swift
+++ b/YourWord/Views/Components/SearchBarView.swift
@@ -9,10 +9,9 @@ import SwiftUI
 
 struct SearchBarView: View {
   @Binding var isLoading: Bool
+  @Binding var searchText: String
   var searchAction: (String) -> Void
 
-  @State private var searchText: String = ""
-  
   var body: some View {
     HStack {
       TextField("Enter passage, keyword...", text: $searchText)
@@ -48,6 +47,7 @@ struct SearchBarView: View {
 #Preview("Default") {
   SearchBarView(
     isLoading: .constant(false),
+    searchText: .constant(""),
     searchAction: {_ in }
   )
 }
@@ -55,6 +55,7 @@ struct SearchBarView: View {
 #Preview("Searching") {
   SearchBarView(
     isLoading: .constant(true),
+    searchText: .constant("God reigns"),
     searchAction: {_ in }
   )
 }

--- a/YourWord/Views/CustomMemorizeView.swift
+++ b/YourWord/Views/CustomMemorizeView.swift
@@ -48,12 +48,12 @@ struct CustomMemorizeView: View {
       }
     }
     .sheet(isPresented: $showScriptureSelector) {
-      ScriptureSelectorView(
+      ScriptureAddView(
+        isLoading: $isLoading,
         cancelAction: handleScriptureSelectorCancel,
         submitAction: { book, chapter, startVerse, endVerse in
           fetchScripture(book: book, chapter: chapter, startVerse: startVerse, endVerse: endVerse)
-        },
-        isLoading: $isLoading
+        }
       )
     }
     .alert(isPresented: $showScriptureDeleteConfirmation) {

--- a/YourWord/Views/CustomMemorizeView.swift
+++ b/YourWord/Views/CustomMemorizeView.swift
@@ -10,13 +10,12 @@ import SwiftUI
 struct CustomMemorizeView: View {
   @Environment(\.modelContext) private var modelContext
   var scripture: Scripture?
-
+  
   @State private var showScriptureSelector = false
   @State private var showScriptureDeleteConfirmation = false
-  @State private var isLoading = false
-
+  
   let bibleVersion = SettingsManager.shared.preferredBibleVersion ?? BibleVersion.NIV
-
+  
   var body: some View {
     ZStack {
       if let scripture = scripture {
@@ -49,10 +48,9 @@ struct CustomMemorizeView: View {
     }
     .sheet(isPresented: $showScriptureSelector) {
       ScriptureAddView(
-        isLoading: $isLoading,
         cancelAction: handleScriptureSelectorCancel,
-        submitAction: { book, chapter, startVerse, endVerse in
-          fetchScripture(book: book, chapter: chapter, startVerse: startVerse, endVerse: endVerse)
+        addAction: { scripture in
+          saveScripture(scripture)
         }
       )
     }
@@ -67,28 +65,17 @@ struct CustomMemorizeView: View {
       )
     }
   }
-
+  
   private func handleScriptureSelectorCancel() {
     showScriptureSelector = false
   }
-
-  private func fetchScripture(book: String, chapter: Int, startVerse: Int, endVerse: Int) {
-    APIService.shared.fetchScripture(book: book, chapter: chapter, startVerse: startVerse, endVerse: endVerse) { result in
-      switch result {
-      case .success(let scripture):
-        DispatchQueue.main.async {
-          scripture.source = .userDefined
-          ScriptureManager.shared.storeScripture(scripture, context: modelContext)
-          isLoading = false
-          showScriptureSelector = false
-        }
-      case .failure(let error):
-        isLoading = false
-        print("Error fetching scripture: \(error.localizedDescription)")
-      }
-    }
+  
+  private func saveScripture(_ scripture: Scripture) {
+    scripture.source = .userDefined
+    ScriptureManager.shared.storeScripture(scripture, context: modelContext)
+    showScriptureSelector = false
   }
-
+  
   private func deleteScripture() {
     if let scripture = scripture {
       ScriptureManager.shared.removeScripture(scripture, context: modelContext)

--- a/YourWord/Views/MemorizeView.swift
+++ b/YourWord/Views/MemorizeView.swift
@@ -46,7 +46,7 @@ struct MemorizeView: View {
         ScrollView(.horizontal, showsIndicators: false) {
           HStack(spacing: 0) {
             ForEach(0..<scriptureViewModel.memoryTexts.count, id: \.self) { index in
-              ScriptureView(text: scriptureViewModel.memoryTexts[index], source: "\(scriptureViewModel.memorySources[index]) \(bibleVersion.rawValue)")
+              ScriptureView(text: scriptureViewModel.memoryTexts[index], reference: "\(scriptureViewModel.memoryReferences[index]) \(bibleVersion.rawValue)")
                 .padding()
                 .frame(width: geometry.size.width)
             }

--- a/YourWord/Views/ScriptureAddView.swift
+++ b/YourWord/Views/ScriptureAddView.swift
@@ -16,9 +16,12 @@ struct ScriptureAddView: View {
 
   @State private var selectionMode: SelectionMode = .keyword
 
+  @State private var searchText: String = ""
   @State private var hasSearched: Bool = false
   @State private var searchResults: [SearchResultScripture] = []
   @State private var errorMessage: String?
+
+  @State private var selectorState = ScriptureSelectionState()
 
   enum SelectionMode: String, CaseIterable {
     case keyword = "Searching Keywords"
@@ -55,6 +58,7 @@ struct ScriptureAddView: View {
         VStack {
           SearchBarView(
             isLoading: $isLoading,
+            searchText: $searchText,
             searchAction: performSearch
           )
 
@@ -80,6 +84,7 @@ struct ScriptureAddView: View {
       case .verse:
         ScriptureSelectorView(
           isLoading: $isLoading,
+          state: $selectorState,
           submitAction: submitAction
         ).transition(.opacity)
       }

--- a/YourWord/Views/ScriptureAddView.swift
+++ b/YourWord/Views/ScriptureAddView.swift
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) Christine Abernathy.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import SwiftUI
+
+struct ScriptureAddView: View {
+  @Binding var isLoading: Bool
+  var cancelAction: () -> Void
+  var submitAction: (String, Int, Int, Int) -> Void
+
+  let bibleVersion = SettingsManager.shared.preferredBibleVersion ?? BibleVersion.NIV
+
+  @State private var selectionMode: SelectionMode = .keyword
+
+  @State private var hasSearched: Bool = false
+  @State private var searchResults: [SearchResultScripture] = []
+  @State private var errorMessage: String?
+
+  enum SelectionMode: String, CaseIterable {
+    case keyword = "Searching Keywords"
+    case verse = "Selecting Verses"
+  }
+
+  var body: some View {
+    VStack(spacing: 20) {
+      HStack {
+        Spacer()
+        Button(action: cancelAction) {
+          Image(systemName: "xmark")
+            .foregroundColor(.gray)
+            .padding()
+        }
+      }
+
+      VStack(alignment: .center, spacing: 10) {
+        Text("Find By")
+          .font(.headline)
+
+        Picker("Selection Mode", selection: $selectionMode) {
+          ForEach(SelectionMode.allCases, id: \.self) { mode in
+            Text(mode.rawValue).tag(mode)
+          }
+        }
+        .pickerStyle(SegmentedPickerStyle())
+      }
+      .padding([.bottom], 20)
+      .padding(.horizontal)
+
+      switch selectionMode {
+      case .keyword:
+        VStack {
+          SearchBarView(
+            isLoading: $isLoading,
+            searchAction: performSearch
+          )
+
+          if let errorMessage = errorMessage {
+            Text(errorMessage)
+              .foregroundColor(.red)
+              .padding()
+          } else if hasSearched {
+            ScriptureSearchResultsView(
+              allResults: searchResults,
+              onResultTap: { scripture in
+                submitAction(
+                  scripture.passage.book,
+                  scripture.passage.chapter,
+                  scripture.passage.startVerse,
+                  scripture.passage.endVerse
+                )
+              }
+            )
+          }
+        }
+        .transition(.opacity)
+      case .verse:
+        ScriptureSelectorView(
+          isLoading: $isLoading,
+          submitAction: submitAction
+        ).transition(.opacity)
+      }
+
+      Spacer()
+    }
+    .padding()
+  }
+
+  private func performSearch(_ query: String) {
+    guard !query.isEmpty else {
+      searchResults = []
+      errorMessage = nil
+      isLoading = false
+      hasSearched = false
+      return
+    }
+
+    isLoading = true
+    errorMessage = nil
+
+    APIService.shared.searchScriptures(version: bibleVersion, text: query) { result in
+      DispatchQueue.main.async {
+        self.isLoading = false
+        self.hasSearched = true
+
+        switch result {
+        case .success(let scriptures):
+          self.searchResults = scriptures
+          self.errorMessage = nil
+        case .failure(let error):
+          self.searchResults = []
+          self.errorMessage = "An error occurred while searching: \(error.localizedDescription)"
+        }
+      }
+    }
+  }
+}
+
+#Preview {
+  let _ = previewContainer
+  return ScriptureAddView(
+    isLoading: .constant(false),
+    cancelAction: {},
+    submitAction: {_,_,_,_ in }
+  )
+}

--- a/YourWord/Views/ScriptureSearchResultsView.swift
+++ b/YourWord/Views/ScriptureSearchResultsView.swift
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) Christine Abernathy.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import SwiftUI
+
+struct ScriptureSearchResultsView: View {
+  let allResults: [SearchResultScripture]
+  let onResultTap: (SearchResultScripture) -> Void
+  
+  @State private var displayedResults: [SearchResultScripture] = []
+  @State private var currentPage: Int = 1
+  @State private var tappedResultId: UUID?
+  private let resultsPerPage: Int = 10
+  
+  var body: some View {
+    Group {
+      if allResults.isEmpty {
+        Text("No results found")
+          .foregroundColor(.gray)
+          .padding()
+      } else {
+        List {
+          ForEach(displayedResults) { result in
+            ScriptureRowView(scripture: result, isTapped: tappedResultId == result.id)
+              .onTapGesture {
+                withAnimation(.easeInOut(duration: 0.3)) {
+                  tappedResultId = result.id
+                }
+                onResultTap(result)
+                
+                // Reset the tapped state after a delay
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                  withAnimation(.easeInOut(duration: 0.3)) {
+                    tappedResultId = nil
+                  }
+                }
+              }
+          }
+          if hasMoreResults {
+            ProgressView()
+              .onAppear {
+                loadMoreResults()
+              }
+          }
+        }
+      }
+    }
+    .onAppear {
+      loadMoreResults()
+    }
+  }
+  
+  private var hasMoreResults: Bool {
+    displayedResults.count < allResults.count
+  }
+  
+  private func loadMoreResults() {
+    let startIndex = (currentPage - 1) * resultsPerPage
+    let endIndex = min(startIndex + resultsPerPage, allResults.count)
+    
+    guard startIndex < endIndex else {
+      // This guard prevents the range error
+      return
+    }
+    
+    let newResults = Array(allResults[startIndex..<endIndex])
+    displayedResults.append(contentsOf: newResults)
+    currentPage += 1
+  }
+}
+
+#Preview {
+  let _ = previewContainer
+  let scriptures = PreviewData.searchResultScriptures
+  return ScriptureSearchResultsView(
+    allResults: scriptures,
+    onResultTap: { _ in }
+  )
+}


### PR DESCRIPTION
Related to #17 

Felt like picking scriptures by book, chapter, verses wasn't enough. Need a way for a user who doesn't know this info to search for scripture verse by keyword. This adds that functionality.

<!-- You can skip this if you're fixing a typo. -->

Now users can go to the "Your Verses" screen where the default is search by verse. To simplify the UI, the select by verses is only shown if the user selects that option. Searching by keyword shows a list of the verses and the user can tap on one to add it to their list.

To support this feature, the API has added an endpoint from Bolls Life API to provide the backend functionality.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Test plan (required)**
1. Open app and tap on Your Verses
2. Enter a text in the text field. ex: "Test"
3. View results and verify that the keyword is in each result
4. Tap one of the results
5. Verify that you now have the scripture available to memorize
6. Tap on the Pick by Verses option and verify that this flow works as before
7. Test error flows. ex: locally stopping the server and verifying a toast error is shown.

Demonstrate the code is solid. Example: Screenshots / videos are helpful if the pull request changes UI.
<img width="447" alt="Screenshot 2024-07-14 at 2 06 33 AM" src="https://github.com/user-attachments/assets/b86597b3-c043-4905-8500-8ec62f75a9b0">
![Simulator Screenshot - iPhone 15 Pro - 2024-07-14 at 02 06 52](https://github.com/user-attachments/assets/6c9c99a5-0a32-49dc-9cb4-be535dfbd234)
![Simulator Screenshot - iPhone 15 Pro - 2024-07-14 at 02 07 01](https://github.com/user-attachments/assets/ad149ec8-8734-46ec-9827-613468fd8a77)



