### PR TITLE
Add bible version selector to search

### DIFF
--- a/YourWord.xcodeproj/project.pbxproj
+++ b/YourWord.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		CB3FF8792C04251900871CCD /* APIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB3FF8782C04251900871CCD /* APIService.swift */; };
 		CB5314A02B9467610003867A /* PreviewData.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB53149F2B9467610003867A /* PreviewData.swift */; };
 		CB5314A32B9472F80003867A /* PreviewModelContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB5314A22B9472F80003867A /* PreviewModelContainer.swift */; };
+		CB79DEAD2C7A6D5A00713AD6 /* BibleVersionSelectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB79DEAC2C7A6D5A00713AD6 /* BibleVersionSelectorView.swift */; };
 		CB91397D2BA1B09E00C8D8B0 /* ToolbarLinkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB91397C2BA1B09E00C8D8B0 /* ToolbarLinkView.swift */; };
 		CB9432AD2B60C997005F9E48 /* ScriptureViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9432AC2B60C997005F9E48 /* ScriptureViewModel.swift */; };
 		CB9432AF2B64B1D1005F9E48 /* OnboardingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9432AE2B64B1D1005F9E48 /* OnboardingManager.swift */; };
@@ -113,6 +114,7 @@
 		CB3FF8782C04251900871CCD /* APIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIService.swift; sourceTree = "<group>"; };
 		CB53149F2B9467610003867A /* PreviewData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewData.swift; sourceTree = "<group>"; };
 		CB5314A22B9472F80003867A /* PreviewModelContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewModelContainer.swift; sourceTree = "<group>"; };
+		CB79DEAC2C7A6D5A00713AD6 /* BibleVersionSelectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BibleVersionSelectorView.swift; sourceTree = "<group>"; };
 		CB91397C2BA1B09E00C8D8B0 /* ToolbarLinkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolbarLinkView.swift; sourceTree = "<group>"; };
 		CB9432AC2B60C997005F9E48 /* ScriptureViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptureViewModel.swift; sourceTree = "<group>"; };
 		CB9432AE2B64B1D1005F9E48 /* OnboardingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingManager.swift; sourceTree = "<group>"; };
@@ -336,6 +338,7 @@
 				CB3188822C33B3FA00965152 /* TestamentFilterView.swift */,
 				CB31888C2C3C280500965152 /* SearchBarView.swift */,
 				CB3188942C42657E00965152 /* ScriptureRowView.swift */,
+				CB79DEAC2C7A6D5A00713AD6 /* BibleVersionSelectorView.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -526,6 +529,7 @@
 				CB9432B32B8AA760005F9E48 /* Bible.swift in Sources */,
 				CB91397D2BA1B09E00C8D8B0 /* ToolbarLinkView.swift in Sources */,
 				CBFFAB382B0B4F2400C864C9 /* ModelContext+sqliteCommand.swift in Sources */,
+				CB79DEAD2C7A6D5A00713AD6 /* BibleVersionSelectorView.swift in Sources */,
 				CB3188772C313E6C00965152 /* AddButtonView.swift in Sources */,
 				CBF969142B14A87D003D90FE /* Passage.swift in Sources */,
 				CB1AC3C52C4D9006007A080B /* PreviewView.swift in Sources */,

--- a/YourWord/Views/Components/BibleVersionSelectorView.swift
+++ b/YourWord/Views/Components/BibleVersionSelectorView.swift
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Christine Abernathy.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import SwiftUI
+
+struct BibleVersionSelectorView: View {
+  @AppStorage(SettingsManager.SettingsKeys.bibleVersion.rawValue) var selectedVersion: BibleVersion = .NIV
+
+  var body: some View {
+    Picker("Select Version", selection: $selectedVersion) {
+      ForEach(BibleVersion.allCases, id: \.self) { version in
+        Text(version.rawValue)
+          .tag(version)
+      }
+    }
+    .pickerStyle(SegmentedPickerStyle())
+    .onChange(of: selectedVersion) {
+      onChange()
+    }
+  }
+
+  private func onChange() {
+    SettingsManager.shared.updateBibleVersion(selectedVersion)
+  }
+}
+
+#Preview {
+  BibleVersionSelectorView()
+}

--- a/YourWord/Views/Components/ScriptureSelectorView.swift
+++ b/YourWord/Views/Components/ScriptureSelectorView.swift
@@ -71,6 +71,7 @@ struct ScriptureSelectorView: View {
   private func onSelectedBookChange() {
     state.selectedChapter = 1
     onSelectedChapterChange()
+    setupChapterVerses()
   }
 
   private func onSelectedChapterChange() {

--- a/YourWord/Views/ScriptureAddView.swift
+++ b/YourWord/Views/ScriptureAddView.swift
@@ -106,6 +106,8 @@ struct ScriptureAddView: View {
           }
         }
       )
+      BibleVersionSelectorView()
+      .padding(.horizontal)
 
       if hasSearched {
         ScriptureSearchResultsView(
@@ -162,7 +164,9 @@ struct ScriptureAddView: View {
     }
 
     errorMessage = nil
+    searchResults = []
     isLoading = true
+    hasSearched = false
 
     do {
       let scriptures  = try await APIService.shared.searchScriptures(version: bibleVersion, text: query)

--- a/YourWord/Views/ScripturesListView.swift
+++ b/YourWord/Views/ScripturesListView.swift
@@ -11,7 +11,7 @@ import SwiftData
 struct ScripturesListView: View {
   @Environment(\.modelContext) private var modelContext
   @Query(filter: #Predicate<Scripture> { $0.completed },
-         sort: \Scripture.createdAt, order: .forward) private var scriptures: [Scripture]
+         sort: \Scripture.createdAt, order: .reverse) private var scriptures: [Scripture]
 
   var body: some View {
     Group {

--- a/YourWord/Views/SettingsView.swift
+++ b/YourWord/Views/SettingsView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct SettingsView: View {
   @AppStorage(SettingsManager.SettingsKeys.notificationTime.rawValue) private var preferredNotificationTime: Date = SettingsManager.shared.defaultDate()
-  @AppStorage(SettingsManager.SettingsKeys.bibleVersion.rawValue) var preferredBibleVersion: BibleVersion = .NIV
   @AppStorage(SettingsManager.SettingsKeys.dailyRevealOverride.rawValue) var dailyRevealOverride: Bool = false
 
   var body: some View {
@@ -23,16 +22,7 @@ struct SettingsView: View {
         }
 
         Section(header: Text("Bible Version")) {
-          Picker("Select Version", selection: $preferredBibleVersion) {
-            ForEach(BibleVersion.allCases, id: \.self) { version in
-              Text(version.rawValue)
-                .tag(version)
-            }
-          }
-          .pickerStyle(SegmentedPickerStyle())
-          .onChange(of: preferredBibleVersion) {
-            updateBibleVersion()
-          }
+          BibleVersionSelectorView()
         }
 
         Section(header: Text("Daily Memorization")) {
@@ -61,10 +51,6 @@ struct SettingsView: View {
        let minute = components.minute {
       NotificationManager.shared.configureUserNotifications(hour: hour, minute: minute)
     }
-  }
-
-  private func updateBibleVersion() {
-    SettingsManager.shared.updateBibleVersion(preferredBibleVersion)
   }
 
   private func updateDailyRevealOverride() {


### PR DESCRIPTION
Changes based on feedback from testers:

- Should be able to select the Bible translation when searching to add a verse
- It would be good to view the list of saved verses in reverse order, by recent first. Perhaps later this could be configurable

There are also some bug fixes here:

- When adding a verse and selecting a different book of the bible, the chapter and verses don't load correctly
- Back to back searches don't show the new search results
